### PR TITLE
Add 'dd' keybinding for SQHDatabase

### DIFF
--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -41,6 +41,20 @@ function! mysql#ShowTablesForDatabase(database)
     call sqhell#InsertResultsToNewBuffer('SQHTable', mysql#GetResultsFromQuery('SHOW TABLES FROM ' . a:database))
 endfunction
 
+"Drops database at cursor
+"Can also be ran by pressing 'dd' in
+"an SQHDatabase buffer
+"Arguments:
+" - database: string, the database name
+" - show: boolean, show databases?
+function! mysql#DropDatabase(database, show)
+    call mysql#GetResultsFromQuery('DROP DATABASE ' . a:database)
+    if(a:show)
+      :bd
+      call mysql#ShowDatabases()
+    endif
+endfunction
+
 "TODO - Is platform agnostic and should not be inthe mysql file.
 "Inserts SQL results into a new temporary buffer"
 function! mysql#ExecuteCommand(command)

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -48,10 +48,17 @@ endfunction
 " - database: string, the database name
 " - show: boolean, show databases?
 function! mysql#DropDatabase(database, show)
-    call mysql#GetResultsFromQuery('DROP DATABASE ' . a:database)
-    if(a:show)
-      :bd
-      call mysql#ShowDatabases()
+    if(!g:i_like_to_live_life_dangerously)
+        let prompt = confirm('Do you really want to drop the database: ' . a:database . '?', "&Yes\n&No", 2)
+    else
+        let prompt = 1
+    endif
+    if(prompt == 1)
+        call mysql#GetResultsFromQuery('DROP DATABASE ' . a:database)
+        if(a:show)
+          :bd
+          call mysql#ShowDatabases()
+        endif
     endif
 endfunction
 

--- a/doc/sqhell.txt
+++ b/doc/sqhell.txt
@@ -152,5 +152,9 @@ SQHDatabase                                                  *sqhell-sqhdatabase
 
         Note this opens a buffer with a filetype of SQHTable
 
+    `dd` - Drop the database.
+
+         Note this reload the current SQHDatabase buffer
+
 
 vim:tw=78:ts=8:ft=help:norl:

--- a/doc/sqhell.txt
+++ b/doc/sqhell.txt
@@ -49,6 +49,13 @@ the `autoload` directory.
 
 i.e. `let g:sqh_provider = 'postgres'`
 
+g:i_like_to_live_life_dangerously                          *sqhell-danger-prompt*
+
+Should SQHell prompt you before executing a dangerous action?
+Set to a non-zero value to disable the prompt.
+Default is 0
+
+
 ===============================================================================
 2. Commands                                                     *sqhell-commands*
 
@@ -67,6 +74,13 @@ SQHShowTablesForDatabase                        *sqhell-show-tables-for-database
     Shows all tables for a given database.
     Note This creates a buffer with a filetype of SQHTable.
     See 'sqhell-filetypes'
+
+SQHDropDatabase                                            *sqhell-drop-database*
+
+    Arguments: database name
+    Example: SQHDropDatabase Users
+
+    Drops the given database.
 
 SQHExecuteFile                                              *sqhell-execute-file*
 

--- a/ftplugin/SQHDatabase.vim
+++ b/ftplugin/SQHDatabase.vim
@@ -1,2 +1,3 @@
 "Select * from the selected table
 noremap <buffer> e :call mysql#ShowTablesForDatabase(expand('<cword>'))<cr>
+noremap <buffer> dd :call mysql#DropDatabase(expand('<cword>'), 1)<cr>

--- a/plugin/sqhell.vim
+++ b/plugin/sqhell.vim
@@ -14,3 +14,4 @@ command! -nargs=1 SQHExecuteCommand execute ":call " . g:sqh_provider . "#Execut
 command! -nargs=0 SQHExecuteLine execute ":call " . g:sqh_provider . "#ExecuteLine()"
 command! -range -nargs=0 SQHExecuteBlock execute "<line1>,<line2>:call " . g:sqh_provider . "#ExecuteBlock()"
 command! -nargs=1 SQHSwitchConnection :call sqhell#SwitchConnection(<q-args>)
+command! -nargs=1 SQHDropDatabase :call mysql#DropDatabase(<q-args>, 0)

--- a/plugin/sqhell.vim
+++ b/plugin/sqhell.vim
@@ -6,6 +6,7 @@ let g:loaded_sqhell = 1
 let g:sqh_provider = get(g:, 'sqh_provider', 'mysql')
 let g:sqh_connection = get(g:, 'sqh_connection', 'default')
 let g:sqh_results_limit = get(g:, 'sqh_results_limit', 100)
+let g:i_like_to_live_life_dangerously = get(g:, 'i_like_to_live_life_dangerously', 0)
 
 command! -nargs=0 SQHShowDatabases execute ":call " . g:sqh_provider . "#ShowDatabases()"
 command! -nargs=1 SQHShowTablesForDatabase execute ":call " . g:sqh_provider . "#ShowTablesForDatabase(<q-args>)"


### PR DESCRIPTION
Added enhancement for issue #10 .
Functionality:
- function **mysql#DropDatabase(database, show)**
- command **SQHDropDatabase** calls **mysql#DropDatabase**, gets _database_ argument from command line and _show_ is set to 0 (so it doesnt open new buffer with database list)
- key mapping 'dd' for **mysql#DropDatabase** function, gets _database_ argument from cursor and _show_ is set to 1 (closes current SQHDatabase buffer and open a new updated one)