### PR TITLE
Add 'dd' keybinding for SQHTable buffer

### DIFF
--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -43,7 +43,7 @@ endfunction
 
 "Drops database at cursor
 "Can also be ran by pressing 'dd' in
-"an SQHDatabase buffer
+"a SQHDatabase buffer
 "Arguments:
 " - database: string, the database name
 " - show: boolean, show databases?
@@ -58,6 +58,36 @@ function! mysql#DropDatabase(database, show)
         if(a:show)
           :bd
           call mysql#ShowDatabases()
+        endif
+    endif
+endfunction
+
+"Drops table by pressing 'dd'
+"in a SQHTable buffer
+"Arguments:
+" - table: string, the table name
+" - show: boolean, show databases?
+function! mysql#DropTableSQHTableBuf(table, show)
+    let db = mysql#GetDatabaseName()
+    call mysql#DropTableFromDatabase(db, a:table, a:show)
+endfunction
+
+"Drops table
+"Arguments:
+" - database: string, the database name
+" - table: string, the table name
+" - show: boolean, show databases?
+function! mysql#DropTableFromDatabase(database, table, show)
+    if(!g:i_like_to_live_life_dangerously)
+        let prompt = confirm('Do you really want to drop the table: ' . a:table . ' from the database: ' . a:database . "?", "&Yes\n&No", 2)
+    else
+        let prompt = 1
+    endif
+    if(prompt == 1)
+        call mysql#GetResultsFromQuery('DROP TABLE ' . a:database . "." . a:table)
+        if(a:show)
+            :bd
+            call mysql#ShowTablesForDatabase(a:database)
         endif
     endif
 endfunction

--- a/doc/sqhell.txt
+++ b/doc/sqhell.txt
@@ -82,6 +82,13 @@ SQHDropDatabase                                            *sqhell-drop-database
 
     Drops the given database.
 
+SQHDropTableFromDatabase                        *sqhell-drop-table-form-database*
+
+    Arguments: database name, table name
+    Example: SQHDropTableFromDatabase Users Profiles
+
+    Drops the given table from the database.
+
 SQHExecuteFile                                              *sqhell-execute-file*
 
     Arguments: filename(optional)
@@ -141,6 +148,10 @@ SQHTable                                                        *sqhell-sqhtable
         Note this opens a buffer with a filetype of SQHResult where more
         mappings will be (not currently) available.
 
+    `dd` - Drop the table.
+
+        Note this reloads the current SQHTable buffer
+
     `K` - Describe the table. An easy way to remember this mapping is that
         K shows man pages and help pages with other vim files, this is
         semantically similar.
@@ -154,7 +165,7 @@ SQHDatabase                                                  *sqhell-sqhdatabase
 
     `dd` - Drop the database.
 
-         Note this reload the current SQHDatabase buffer
+         Note this reloads the current SQHDatabase buffer
 
 
 vim:tw=78:ts=8:ft=help:norl:

--- a/ftplugin/SQHTable.vim
+++ b/ftplugin/SQHTable.vim
@@ -1,3 +1,4 @@
 "Select * from the selected table
 noremap <buffer> e :call mysql#ShowRecordsInTable(expand('<cword>'))<cr>
 noremap <buffer> K :call mysql#DescribeTable(expand('<cword>'))<cr>
+noremap <buffer> dd :call mysql#DropTableSQHTableBuf(expand('<cword>'), 1)<cr>

--- a/plugin/sqhell.vim
+++ b/plugin/sqhell.vim
@@ -16,4 +16,4 @@ command! -nargs=0 SQHExecuteLine execute ":call " . g:sqh_provider . "#ExecuteLi
 command! -range -nargs=0 SQHExecuteBlock execute "<line1>,<line2>:call " . g:sqh_provider . "#ExecuteBlock()"
 command! -nargs=1 SQHSwitchConnection :call sqhell#SwitchConnection(<q-args>)
 command! -nargs=1 SQHDropDatabase execute ":call " . g:sqh_provider . "#DropDatabase(<q-args>, 0)"
-command! -nargs=+ SQHDropTableFromDatabase execute ":call " . g:sqh_provider . "#DropTableFromDatabase(<f-args>, 0)""
+command! -nargs=+ SQHDropTableFromDatabase execute ":call " . g:sqh_provider . "#DropTableFromDatabase(<f-args>, 0)"

--- a/plugin/sqhell.vim
+++ b/plugin/sqhell.vim
@@ -16,3 +16,4 @@ command! -nargs=0 SQHExecuteLine execute ":call " . g:sqh_provider . "#ExecuteLi
 command! -range -nargs=0 SQHExecuteBlock execute "<line1>,<line2>:call " . g:sqh_provider . "#ExecuteBlock()"
 command! -nargs=1 SQHSwitchConnection :call sqhell#SwitchConnection(<q-args>)
 command! -nargs=1 SQHDropDatabase :call mysql#DropDatabase(<q-args>, 0)
+command! -nargs=+ SQHDropTableFromDatabase :call mysql#DropTableFromDatabase(<f-args>, 0)

--- a/plugin/sqhell.vim
+++ b/plugin/sqhell.vim
@@ -15,5 +15,5 @@ command! -nargs=1 SQHExecuteCommand execute ":call " . g:sqh_provider . "#Execut
 command! -nargs=0 SQHExecuteLine execute ":call " . g:sqh_provider . "#ExecuteLine()"
 command! -range -nargs=0 SQHExecuteBlock execute "<line1>,<line2>:call " . g:sqh_provider . "#ExecuteBlock()"
 command! -nargs=1 SQHSwitchConnection :call sqhell#SwitchConnection(<q-args>)
-command! -nargs=1 SQHDropDatabase :call mysql#DropDatabase(<q-args>, 0)
-command! -nargs=+ SQHDropTableFromDatabase :call mysql#DropTableFromDatabase(<f-args>, 0)
+command! -nargs=1 SQHDropDatabase execute ":call " . g:sqh_provider . "#DropDatabase(<q-args>, 0)"
+command! -nargs=+ SQHDropTableFromDatabase execute ":call " . g:sqh_provider . "#DropTableFromDatabase(<f-args>, 0)""


### PR DESCRIPTION
Implemented the enhancement from issue #9.

Functionality:
- function **mysql#DropTableFromDatabase(database, table, show)**
- function **mysql#DropTableSQHTableBuf(table, show)**, calls **mysql#DropTableFromDatabase** while getting database from opened _SQHTable_ buffer
- command  **SQHDropTableFromDatabase** calls **mysql#DropTableFromDatabase**, gets _database_ and _table_ arguments from command line and _show_ is set to 0 (so it does not open a _SQHTable_ buffer)
- key mapping 'dd' for **mysql#DropTableSQHTableBuf** function, gets _database_ from **mysql#GetDatabaseName**, _table_ from cursor, and _show_ is set to 1 (reloads the current _SQHTable_ buffer)