### PR TITLE
Add 'dd' keybinding for deleting rows

### DIFF
--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -120,6 +120,6 @@ function! mysql#DeleteRow(row)
         call mysql#GetResultsFromQuery('DELETE FROM ' . db . '.' . table . ' WHERE ' . attr . '=' . "\'" . a:row . "\'")
         :bd
         let query = 'SELECT * FROM ' . db . '.' . table . ' LIMIT ' . g:sqh_results_limit
-        call mysql#ExecuteCommand(query)
+        call sqhell#ExecuteCommand(query)
     endif
 endfunction

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -123,39 +123,3 @@ function! mysql#DeleteRow(row)
         call mysql#ExecuteCommand(query)
     endif
 endfunction
-
-"TODO - Is platform agnostic and should not be inthe mysql file.
-"Inserts SQL results into a new temporary buffer"
-function! mysql#ExecuteCommand(command)
-    call sqhell#InsertResultsToNewBuffer('SQHResult', mysql#GetResultsFromQuery(a:command))
-endfunction
-
-"TODO - Is platform agnostic and should not be inthe mysql file.
-function! mysql#ExecuteBlock() range
-    "TODO extract the block selection out so we can test it
-    let previous_register_content = @"
-    silent! execute a:firstline . ',' . a:lastline . 'y'
-    let query = @"
-    "Restore whatever was in here back to normal
-    let @" = previous_register_content
-    call mysql#ExecuteCommand(query)
-endfunction
-
-"TODO - Is platform agnostic and should not be inthe mysql file.
-"Execute the current line
-function! mysql#ExecuteLine()
-    call mysql#ExecuteCommand(getline('.'))
-endfunction
-
-"TODO - Is platform agnostic and should not be inthe mysql file.
-"Execute the given file
-function! mysql#ExecuteFile(...)
-    let _file = get(a:, 1)
-
-    if a:1 == ''
-        let _file = expand('%:p')
-    endif
-
-    let file_content = join(readfile(_file), "\n")
-    call mysql#ExecuteCommand(file_content)
-endfunction

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -11,7 +11,9 @@ endfunction
 
 "Tables_in_users_table => users_table"
 function! mysql#GetDatabaseName()
+    let savecur = getcurpos()
     let raw_database = split(getline(search('Tables_in_')), 'Tables_in_')[1]
+    call setpos('.', savecur)
     let current_database = substitute(raw_database, '|', '', '')
     return current_database
 endfunction
@@ -98,4 +100,62 @@ endfunction
 "the removal of said crap...
 function! mysql#PostBufferFormat()
     normal gg2dd
+endfunction
+
+"Deletes table row(s) by pressing 'dd'
+"in a SQHResult buffer
+"Arguments:
+" - row: string, the where condition for deleting
+function! mysql#DeleteRow(row)
+    let attr = sqhell#GetColumnName()
+    let list = sqhell#GetTableName()
+    let table = list[0]
+    let db = list[1]
+    if(!g:i_like_to_live_life_dangerously)
+        let prompt = confirm('Do you really want to delete all table rows where column ' . attr . '=' . a:row . ' in ' . db . '.' . table . '?', "&Yes\n&No", 2)
+    else
+        let prompt = 1
+    endif
+    if(prompt == 1)
+        call mysql#GetResultsFromQuery('DELETE FROM ' . db . '.' . table . ' WHERE ' . attr . '=' . "\'" . a:row . "\'")
+        :bd
+        let query = 'SELECT * FROM ' . db . '.' . table . ' LIMIT ' . g:sqh_results_limit
+        call mysql#ExecuteCommand(query)
+    endif
+endfunction
+
+"TODO - Is platform agnostic and should not be inthe mysql file.
+"Inserts SQL results into a new temporary buffer"
+function! mysql#ExecuteCommand(command)
+    call sqhell#InsertResultsToNewBuffer('SQHResult', mysql#GetResultsFromQuery(a:command))
+endfunction
+
+"TODO - Is platform agnostic and should not be inthe mysql file.
+function! mysql#ExecuteBlock() range
+    "TODO extract the block selection out so we can test it
+    let previous_register_content = @"
+    silent! execute a:firstline . ',' . a:lastline . 'y'
+    let query = @"
+    "Restore whatever was in here back to normal
+    let @" = previous_register_content
+    call mysql#ExecuteCommand(query)
+endfunction
+
+"TODO - Is platform agnostic and should not be inthe mysql file.
+"Execute the current line
+function! mysql#ExecuteLine()
+    call mysql#ExecuteCommand(getline('.'))
+endfunction
+
+"TODO - Is platform agnostic and should not be inthe mysql file.
+"Execute the given file
+function! mysql#ExecuteFile(...)
+    let _file = get(a:, 1)
+
+    if a:1 == ''
+        let _file = expand('%:p')
+    endif
+
+    let file_content = join(readfile(_file), "\n")
+    call mysql#ExecuteCommand(file_content)
 endfunction

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -106,18 +106,19 @@ endfunction
 "in a SQHResult buffer
 "Arguments:
 " - row: string, the where condition for deleting
-function! mysql#DeleteRow(row)
+function! mysql#DeleteRow()
+    let row = sqhell#GetColumnValue()
     let attr = sqhell#GetColumnName()
     let list = sqhell#GetTableName()
     let table = list[0]
     let db = list[1]
     if(!g:i_like_to_live_life_dangerously)
-        let prompt = confirm('Do you really want to delete all table rows where column ' . attr . '=' . a:row . ' in ' . db . '.' . table . '?', "&Yes\n&No", 2)
+        let prompt = confirm('Do you really want to delete all table rows where column ' . attr . '=' . "\'" . row . "\'" . ' in ' . db . '.' . table . '?', "&Yes\n&No", 2)
     else
         let prompt = 1
     endif
     if(prompt == 1)
-        call mysql#GetResultsFromQuery('DELETE FROM ' . db . '.' . table . ' WHERE ' . attr . '=' . "\'" . a:row . "\'")
+        call mysql#GetResultsFromQuery('DELETE FROM ' . db . '.' . table . ' WHERE ' . attr . '=' . "\'" . row . "\'")
         :bd
         let query = 'SELECT * FROM ' . db . '.' . table . ' LIMIT ' . g:sqh_results_limit
         call sqhell#ExecuteCommand(query)

--- a/autoload/sqhell.vim
+++ b/autoload/sqhell.vim
@@ -58,3 +58,20 @@ function! sqhell#InsertResultsToNewBuffer(local_filetype, query_results)
     setlocal nowrap
     execute 'setlocal filetype=' . a:local_filetype
 endfunction
+
+function! sqhell#GetColumnName()
+    let savecurpos = getcurpos()
+    call cursor(1, savecurpos[2])
+    let attr = expand('<cword>')
+    call setpos('.', savecurpos)
+    return attr
+endfunction
+
+function! sqhell#GetTableName()
+    let savewin = winnr()
+    wincmd p
+    let table = expand('<cword>')
+    let db = mysql#GetDatabaseName()
+    execute savewin . "wincmd w"
+    return [table, db]
+endfunction

--- a/autoload/sqhell.vim
+++ b/autoload/sqhell.vim
@@ -65,10 +65,33 @@ function! sqhell#GetColumnName()
     let attr = expand('<cword>')
     if(attr =~ "^\+-")
         call cursor(2, savecurpos[2])
-        let attr = expand('<cword>')
     endif
+    let start = col('.')
+    if(getline('.')[col('.')-1] != '|')
+        normal F|
+        let start = col('.')
+    endif
+    normal f|
+    let end = col('.')-2
+    let attr = getline('.')[start:end]
+    let attr = substitute(attr, '^\s*\(.\{-}\)\s*$', '\1', '')
     call setpos('.', savecurpos)
     return attr
+endfunction
+
+function! sqhell#GetColumnValue()
+    let savecurpos = getcurpos()
+    let start = col('.')
+    if(getline('.')[start-1] != '|')
+        normal F|
+        let start = col('.')
+    endif
+    normal f|
+    let end = col('.')-2
+    let val = getline('.')[start:end]
+    let val = substitute(val, '^\s*\(.\{-}\)\s*$', '\1', '')
+    call setpos('.', savecurpos)
+    return val
 endfunction
 
 function! sqhell#GetTableName()

--- a/autoload/sqhell.vim
+++ b/autoload/sqhell.vim
@@ -63,6 +63,10 @@ function! sqhell#GetColumnName()
     let savecurpos = getcurpos()
     call cursor(1, savecurpos[2])
     let attr = expand('<cword>')
+    if(attr =~ "^\+-")
+        call cursor(2, savecurpos[2])
+        let attr = expand('<cword>')
+    endif
     call setpos('.', savecurpos)
     return attr
 endfunction
@@ -71,7 +75,8 @@ function! sqhell#GetTableName()
     let savewin = winnr()
     wincmd p
     let table = expand('<cword>')
-    let db = mysql#GetDatabaseName()
+    let tmp_db = mysql#GetDatabaseName()
+    let db = substitute(tmp_db, '^\s*\(.\{-}\)\s*$', '\1', '')
     execute savewin . "wincmd w"
     return [table, db]
 endfunction

--- a/doc/sqhell.txt
+++ b/doc/sqhell.txt
@@ -166,7 +166,14 @@ SQHDatabase                                                  *sqhell-sqhdatabase
 
     `dd` - Drop the database.
 
-         Note this reloads the current SQHDatabase buffer
+        Note this reloads the current SQHDatabase buffer
+
+
+SQHResult                                                      *sqhell-sqhresult*
+
+    `dd` - Delete the selected row.
+
+        Note this reloads the current SQHResult buffer
 
 
 vim:tw=78:ts=8:ft=help:norl:

--- a/ftplugin/SQHResult.vim
+++ b/ftplugin/SQHResult.vim
@@ -1,1 +1,2 @@
 " nnoremap <buffer> dd :echo 'Deletions would happen here'
+noremap <buffer> dd :call mysql#DeleteRow(expand('<cword>'))<cr>

--- a/ftplugin/SQHResult.vim
+++ b/ftplugin/SQHResult.vim
@@ -1,2 +1,2 @@
 " nnoremap <buffer> dd :echo 'Deletions would happen here'
-noremap <buffer> dd :call mysql#DeleteRow(expand('<cword>'))<cr>
+noremap <buffer> dd :call mysql#DeleteRow()<cr>


### PR DESCRIPTION
Implemented enhancement from issue #8.

Functionality:
- function **sqhell#GetTableName()**, function for getting table and database name for the opened SQHResult (works only with workflow: show database list -> show tables from database -> show rows from table -> delete row(s))
- function **sqhell#GetColumnName()**, function for getting the column name for the value under the cursor
- function **mysql#DeleteRow(row)**, gets table and database names from **sqhell#GetTableName** and column from **sqhell#GetColumnName**; drops rows where condition _column-name_ == _row_ is true

**sqhell#GetColumnName** and **mysql#DeleteRow** detail explanation:
Because we can't know by what column the user wants do delete row(s), you can choose it with the cursor.

Example:
```
| Attr1 | Attr2 |
+------+-------+
|      1 | test1 |
|      2 | test2 |
|      3 | test2 |
+------+-------+
```

If your cursor is anywhere from the first **|** to the <number> (1, 2, or 3), the executed query will be:
`DELETE FROM database.table WHERE Attr1="<number>"`

If your cursor is anywhere from the second **|** to the <string> (test1, test2, test2), the executed query will be:
`DELETE FROM database.table WHERE Attr2="<string>"`

Basically when pressing 'dd' it saves the current cursor position and then moves the cursor to the first line (does not change the column) and gets the column name to use for the DELETE statement.

I hope the explanation is good enough.