### PR TITLE
Add command and keybindings to sort results

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,13 @@ i.e. `SQHSwitchConnection live`
 I **strongly** suggest that the above configuration details are kept *outside*
 of version control and gitignored in your global gitignore.
 
+## Default Keybindings
+
+Press `s` to sort results by the column the cursor is on
+Press `S` to sort results by the column the cursor is on (in reverse)
+
+For more sorting options, you can use `:SQHSortResults` with extra arguments for the unix sort command, a la `:SQHSortResults '-rn'`. It will always sort by the column the cursor is located on.
+
 ## Contributing
 
 Please see the [Contributing guidelines](CONTRIBUTING.md) if you would like to make SQHell even better!

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ of version control and gitignored in your global gitignore.
 Press `s` to sort results by the column the cursor is on
 Press `S` to sort results by the column the cursor is on (in reverse)
 
-For more sorting options, you can use `:SQHSortResults` with extra arguments for the unix sort command, a la `:SQHSortResults '-rn'`. It will always sort by the column the cursor is located on.
+For more sorting options, you can use `:SQHSortResults` with extra arguments for the unix sort command, a la `:SQHSortResults -rn`. It will always sort by the column the cursor is located on.
 
 ## Contributing
 

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -92,6 +92,14 @@ function! mysql#DropTableFromDatabase(database, table, show)
     endif
 endfunction
 
+function! mysql#SortResults(sort_options)
+    let cursor_pos = getpos('.')
+    let line_until_cursor = getline('.')[:cursor_pos[2]]
+    let sort_column = len(substitute(line_until_cursor, '[^|]', '', 'g'))
+    exec '4,$!sort -k ' . sort_column . ' -t \| ' . a:sort_options
+    call setpos('.', cursor_pos)
+endfunction
+
 "Each provider may paste some extra
 "crap that is irrelevant to us
 "Use this function to customise

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -96,7 +96,10 @@ function! mysql#SortResults(sort_options)
     let cursor_pos = getpos('.')
     let line_until_cursor = getline('.')[:cursor_pos[2]]
     let sort_column = len(substitute(line_until_cursor, '[^|]', '', 'g'))
-    exec '4,$!sort -k ' . sort_column . ' -t \| ' . a:sort_options
+    if sort_column == 0
+      let sort_column = 1
+    endif
+    exec '4,$-1!sort -k ' . sort_column . ' -t \| ' . a:sort_options
     call setpos('.', cursor_pos)
 endfunction
 

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -99,6 +99,7 @@ function! mysql#SortResults(sort_options)
     if sort_column == 0
       let sort_column = 1
     endif
+    let sort_column += 1
     exec '4,$-1!sort -k ' . sort_column . ' -t \| ' . a:sort_options
     call setpos('.', cursor_pos)
 endfunction

--- a/autoload/psql.vim
+++ b/autoload/psql.vim
@@ -15,6 +15,14 @@ function! psql#ShowDatabases()
     call sqhell#InsertResultsToNewBuffer('SQHDatabase', psql#GetResultsFromQuery(db_query))
 endfunction
 
+function! psql#SortResults(sort_options)
+    let cursor_pos = getpos('.')
+    let line_until_cursor = getline('.')[:cursor_pos[2]]
+    let sort_column = len(substitute(line_until_cursor, '[^|]', '', 'g')) + 1
+    exec '3,$!sort -k ' . sort_column . ' -t \| ' . a:sort_options
+    call setpos('.', cursor_pos)
+endfunction
+
 function! psql#PostBufferFormat()
     normal ggdd
     normal Gdkgg

--- a/autoload/psql.vim
+++ b/autoload/psql.vim
@@ -17,5 +17,6 @@ endfunction
 
 function! psql#PostBufferFormat()
     normal ggdd
+    normal Gdkgg
 endfunction
 

--- a/doc/sqhell.txt
+++ b/doc/sqhell.txt
@@ -133,7 +133,7 @@ SQHSwitchConnection                                   *sqhell-switch-connection*
 SQHSortResults                                                *sqh-sort-results*
 
     Arguments: arguments for unix sort command
-    Example: SQHSortResults '-rn'
+    Example: SQHSortResults -rn
 
     Sorts results by the column the cursor is currently located on.
 
@@ -180,11 +180,11 @@ SQHResult                                                         *sqh-sqhresult
 
     `s` - Sort results by the column the cursor is on
 
-        Equivalent to `:SQHSortResults '-f'`
+        Equivalent to `:SQHSortResults -f`
 
     `S` - Sort results by the column the cursor is on (in reverse)
 
-        Equivalent to `:SQHSortResults '-fr'`
+        Equivalent to `:SQHSortResults -fr`
 
 
 vim:tw=78:ts=8:ft=help:norl:

--- a/doc/sqhell.txt
+++ b/doc/sqhell.txt
@@ -130,6 +130,13 @@ SQHSwitchConnection                                   *sqhell-switch-connection*
     Switches the connection details to the given host specified
     in g:sqh_connections
 
+SQHSortResults                                                *sqh-sort-results*
+
+    Arguments: arguments for unix sort command
+    Example: SQHSortResults '-rn'
+
+    Sorts results by the column the cursor is currently located on.
+
 
 ===============================================================================
 3. Filetypes                                                   *sqhell-filetypes*
@@ -167,6 +174,17 @@ SQHDatabase                                                  *sqhell-sqhdatabase
     `dd` - Drop the database.
 
          Note this reloads the current SQHDatabase buffer
+
+
+SQHResult                                                         *sqh-sqhresult*
+
+    `s` - Sort results by the column the cursor is on
+
+        Equivalent to `:SQHSortResults '-f'`
+
+    `S` - Sort results by the column the cursor is on (in reverse)
+
+        Equivalent to `:SQHSortResults '-fr'`
 
 
 vim:tw=78:ts=8:ft=help:norl:

--- a/ftplugin/SQHResult.vim
+++ b/ftplugin/SQHResult.vim
@@ -1,3 +1,3 @@
 " nnoremap <buffer> dd :echo 'Deletions would happen here'
-nnoremap <buffer> s :SQHSortResults '-f'<CR>
-nnoremap <buffer> S :SQHSortResults '-fr'<CR>
+nnoremap <buffer> <silent> s :SQHSortResults -f<CR>
+nnoremap <buffer> <silent> S :SQHSortResults -fr<CR>

--- a/ftplugin/SQHResult.vim
+++ b/ftplugin/SQHResult.vim
@@ -1,1 +1,3 @@
 " nnoremap <buffer> dd :echo 'Deletions would happen here'
+nnoremap <buffer> s :SQHSortResults '-f'<CR>
+nnoremap <buffer> S :SQHSortResults '-fr'<CR>

--- a/plugin/sqhell.vim
+++ b/plugin/sqhell.vim
@@ -17,4 +17,4 @@ command! -range -nargs=0 SQHExecuteBlock <line1>,<line2>:call sqhell#ExecuteBloc
 command! -nargs=1 SQHSwitchConnection call sqhell#SwitchConnection(<q-args>)
 command! -nargs=1 SQHDropDatabase execute ":call " . g:sqh_provider . "#DropDatabase(<q-args>, 0)"
 command! -nargs=+ SQHDropTableFromDatabase execute ":call " . g:sqh_provider . "#DropTableFromDatabase(<f-args>, 0)"
-command! -nargs=* SQHSortResults execute ":call " . g:sqh_provider . "#SortResults('<q-args>')"
+command! -nargs=* SQHSortResults execute ':call ' . g:sqh_provider . '#SortResults(<f-args>)'

--- a/plugin/sqhell.vim
+++ b/plugin/sqhell.vim
@@ -17,4 +17,4 @@ command! -range -nargs=0 SQHExecuteBlock <line1>,<line2>:call sqhell#ExecuteBloc
 command! -nargs=1 SQHSwitchConnection call sqhell#SwitchConnection(<q-args>)
 command! -nargs=1 SQHDropDatabase execute ":call " . g:sqh_provider . "#DropDatabase(<q-args>, 0)"
 command! -nargs=+ SQHDropTableFromDatabase execute ":call " . g:sqh_provider . "#DropTableFromDatabase(<f-args>, 0)"
-command! -nargs=* SQHSortResults execute ":call " . g:sqh_provider . "#SortResults(<q-args>)"
+command! -nargs=* SQHSortResults execute ":call " . g:sqh_provider . "#SortResults('<q-args>')"

--- a/plugin/sqhell.vim
+++ b/plugin/sqhell.vim
@@ -17,3 +17,4 @@ command! -range -nargs=0 SQHExecuteBlock <line1>,<line2>:call sqhell#ExecuteBloc
 command! -nargs=1 SQHSwitchConnection call sqhell#SwitchConnection(<q-args>)
 command! -nargs=1 SQHDropDatabase execute ":call " . g:sqh_provider . "#DropDatabase(<q-args>, 0)"
 command! -nargs=+ SQHDropTableFromDatabase execute ":call " . g:sqh_provider . "#DropTableFromDatabase(<f-args>, 0)"
+command! -nargs=* SQHSortResults execute ":call " . g:sqh_provider . "#SortResults(<q-args>)"


### PR DESCRIPTION
This does a few things:
- Improves the PostBufferFormat function for psql to remove the "(x results)" and blank lines psql appends to the end of query results
- Adds a SQHSortResults command to sort results based on the column the cursor is located on
- Adds default keybindings for s and S to sort results by the current column in ascending or descending order (respectively)

A few things to note:
- I don't have mysql set up so I haven't actually tested whether or not this works for mysql, but from what I see for how mysql returns results, I believe it should work. If someone who uses mysql could test it real quick, that'd be great
- It will not work correctly in buffers that have results from more than one query in them. Right now, executing a file/block in psql with more than one select in it only returns results for the last select statement, so once that gets fixed, I can fix this

btw this is apola from reddit fyi :)