### PR TITLE
Add edit table row functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Inside an SQHResult you can press the following
 
 Inside an SQHInsert you can press the following
 
-`ZZ` to close and save the editied row. This will reopen the previous SQHResult buffer
+`ZZ` to close and save the edited row. This will reopen the previous SQHResult buffer
 
 
 For more sorting options, you can use `:SQHSortResults` with extra arguments for the unix sort command, a la `:SQHSortResults -rn`. It will always sort by the column the cursor is located on.

--- a/README.md
+++ b/README.md
@@ -101,6 +101,15 @@ Inside an SQHResult you can press the following
 
 `dd` to delete the row WHERE the column is the value under the cursor (don't worry... there's a prompt).
 
+`e` to edit the current row. This will open an SQHInsert buffer
+
+
+### SQHInsert
+
+Inside an SQHInsert you can press the following
+
+`ZZ` to close and save the editied row. This will reopen the previous SQHResult buffer
+
 
 For more sorting options, you can use `:SQHSortResults` with extra arguments for the unix sort command, a la `:SQHSortResults -rn`. It will always sort by the column the cursor is located on.
 

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -28,6 +28,7 @@ endfunction
 "This is ran when we press 'e' on an SQHTable buffer
 function! mysql#ShowRecordsInTable(table)
     let l:db = mysql#GetDatabaseName()
+    let l:db = sqhell#TrimString(l:db)
     let l:query = 'SELECT * FROM ' . l:db . '.' . a:table . ' LIMIT ' . g:sqh_results_limit
     call sqhell#ExecuteCommand(l:query)
 endfunction
@@ -143,6 +144,7 @@ function! mysql#EditRow()
     let savecur = getcurpos()
     let head = sqhell#GetTableHeader()
     call setpos('.', savecur)
+    echo b:last_query
     " let list = sqhell#GetTableName()
     " let table = list[0]
     " let db = list[1]
@@ -152,8 +154,12 @@ function! mysql#EditRow()
     if(index != -1)
         let tmp = tmp[0:index-1]
     endif
+    let index = index(tmp, 'LIMIT')
+    if(index != -1)
+        let tmp = tmp[0:index-1]
+    endif
     let tmp = tmp[len(tmp)-1]
-    let tmp = tmp[0:len(tmp)-2]
+    " let tmp = tmp[0:len(tmp)-2]
     let tmp = split(tmp, '\.')
     let db = tmp[0]
     let table = tmp[1]

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -147,7 +147,8 @@ function! mysql#EditRow()
     let table = list[0]
     let db = list[1]
 
-    call sqhell#InsertResultsToNewBuffer('SQHInsert', head . "\n" . csv, 0)
+    :bd
+    call sqhell#InsertResultsToNewBuffer('SQHInsert', "\n" . head . "\n" . csv, 1)
     let b:type = 'edit'
     let b:prev = csv
     let t:tabInfo = db . '.' . table
@@ -177,8 +178,12 @@ function! mysql#CreateUpdateFromCSV()
     let cols = split(cols, ',')
     call cursor(2, 1)
     let vals = getline('.')
-    let vals = split(vals, ',')
-    let b:prev = split(b:prev, ',')
+    let vals = split(vals, '"')
+    let vals = filter(vals, 'v:val != ","')
+    let vals = map(vals, '"\"" . v:val . "\""')
+    let b:prev = split(b:prev, '"')
+    let b:prev = filter(b:prev, 'v:val != ","')
+    let b:prev = map(b:prev, '"\"" . v:val . "\""')
 
     if(len(cols) != len(vals))
         echom 'Incorrect number of values.'

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -143,9 +143,20 @@ function! mysql#EditRow()
     let savecur = getcurpos()
     let head = sqhell#GetTableHeader()
     call setpos('.', savecur)
-    let list = sqhell#GetTableName()
-    let table = list[0]
-    let db = list[1]
+    " let list = sqhell#GetTableName()
+    " let table = list[0]
+    " let db = list[1]
+    let tmp = b:last_query
+    let tmp = split(tmp, ' ')
+    let index = index(tmp, 'WHERE')
+    if(index != -1)
+        let tmp = tmp[0:index-1]
+    endif
+    let tmp = tmp[len(tmp)-1]
+    let tmp = tmp[0:len(tmp)-2]
+    let tmp = split(tmp, '\.')
+    let db = tmp[0]
+    let table = tmp[1]
 
     :bd
     call sqhell#InsertResultsToNewBuffer('SQHInsert', "\n" . head . "\n" . csv, 1)

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -144,10 +144,6 @@ function! mysql#EditRow()
     let savecur = getcurpos()
     let head = sqhell#GetTableHeader()
     call setpos('.', savecur)
-    echo b:last_query
-    " let list = sqhell#GetTableName()
-    " let table = list[0]
-    " let db = list[1]
     let tmp = b:last_query
     let tmp = split(tmp, ' ')
     let index = index(tmp, 'WHERE')
@@ -159,7 +155,6 @@ function! mysql#EditRow()
         let tmp = tmp[0:index-1]
     endif
     let tmp = tmp[len(tmp)-1]
-    " let tmp = tmp[0:len(tmp)-2]
     let tmp = split(tmp, '\.')
     let db = tmp[0]
     let table = tmp[1]

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -89,7 +89,7 @@ function! mysql#DropTableFromDatabase(database, table, show)
         call mysql#GetResultsFromQuery('DROP TABLE ' . a:database . "." . a:table)
         if(a:show)
             :bd
-            call mysql#ShowTablesForDatabase(a:database)
+            call sqhell#ShowTablesForDatabase(a:database)
         endif
     endif
 endfunction
@@ -208,4 +208,60 @@ function! mysql#CreateUpdateFromCSV()
 
     let query = 'UPDATE ' . t:tabInfo . assign . where
     return query
+endfunction
+
+function! mysql#GetTableHeader()
+    call cursor(1, 1)
+    let line = getline('.')
+    if(line[0] != '|')
+        call cursor(2, 1)
+    endif
+    let line = getline('.')
+    let line = split(line, '|')
+    let line = map(line, "sqhell#TrimString(v:val)")
+    let line = join(line, ",")
+    return line
+endfunction
+
+function! mysql#CreateCSVFromRow(row)
+    let csv = split(a:row, "|")
+    let csv = map(csv, "sqhell#TrimString(v:val)")
+    let csv = map(csv, '"\"" . v:val . "\""')
+    let csv = join(csv, ",")
+    return csv
+endfunction
+
+function! mysql#GetColumnName()
+    let savecurpos = getcurpos()
+    call cursor(1, savecurpos[2])
+    let attr = expand('<cword>')
+    if(attr =~ "^\+-")
+        call cursor(2, savecurpos[2])
+    endif
+    let start = col('.')
+    if(getline('.')[col('.')-1] != '|')
+        normal F|
+        let start = col('.')
+    endif
+    normal f|
+    let end = col('.')-2
+    let attr = getline('.')[start:end]
+    let attr = sqhell#TrimString(attr)
+    call setpos('.', savecurpos)
+    return attr
+endfunction
+
+function! mysql#GetColumnValue()
+    let savecurpos = getcurpos()
+    let start = col('.')
+    if(getline('.')[start-1] != '|')
+        normal F|
+        let start = col('.')
+    endif
+    normal f|
+    let end = col('.')-2
+    let val = getline('.')[start:end]
+    let val = sqhell#TrimString(val)
+    call setpos('.', savecurpos)
+    return val
 endfunction

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -22,7 +22,7 @@ endfunction
 function! mysql#DescribeTable(table)
     let db = mysql#GetDatabaseName()
     let query = 'DESCRIBE ' . db . '.' . a:table
-    call sqhell#InsertResultsToNewBuffer('SQHUnspecified', mysql#GetResultsFromQuery(query))
+    call sqhell#InsertResultsToNewBuffer('SQHUnspecified', mysql#GetResultsFromQuery(query), 1)
 endfunction
 
 "This is ran when we press 'e' on an SQHTable buffer
@@ -33,14 +33,14 @@ function! mysql#ShowRecordsInTable(table)
 endfunction
 
 function! mysql#ShowDatabases()
-    call sqhell#InsertResultsToNewBuffer('SQHDatabase', mysql#GetResultsFromQuery('SHOW DATABASES'))
+    call sqhell#InsertResultsToNewBuffer('SQHDatabase', mysql#GetResultsFromQuery('SHOW DATABASES'), 1)
 endfunction
 
 "Shows all tables for a given database
 "Can also be ran by pressing 'e' in
 "an SQHDatabase buffer
 function! mysql#ShowTablesForDatabase(database)
-    call sqhell#InsertResultsToNewBuffer('SQHTable', mysql#GetResultsFromQuery('SHOW TABLES FROM ' . a:database))
+    call sqhell#InsertResultsToNewBuffer('SQHTable', mysql#GetResultsFromQuery('SHOW TABLES FROM ' . a:database), 1)
 endfunction
 
 "Drops database at cursor
@@ -147,19 +147,10 @@ function! mysql#EditRow()
     let table = list[0]
     let db = list[1]
 
-    :bd
-    new
+    call sqhell#InsertResultsToNewBuffer('SQHInsert', head . "\n" . csv, 0)
     let b:type = 'edit'
     let b:prev = csv
     let t:tabInfo = db . '.' . table
-    call append(0, head)
-    call append(1, csv)
-
-    setlocal buftype=nofile
-    setlocal bufhidden=hide
-    setlocal noswapfile
-    setlocal nowrap
-    execute 'setlocal filetype=SQHInsert'
 endfunction
 
 function! mysql#AddRow()

--- a/autoload/sqhell.vim
+++ b/autoload/sqhell.vim
@@ -79,51 +79,23 @@ function! sqhell#DescribeTable(table)
 endfunction
 
 function! sqhell#GetColumnName()
-    let savecurpos = getcurpos()
-    call cursor(1, savecurpos[2])
-    let attr = expand('<cword>')
-    if(attr =~ "^\+-")
-        call cursor(2, savecurpos[2])
-    endif
-    let start = col('.')
-    if(getline('.')[col('.')-1] != '|')
-        normal F|
-        let start = col('.')
-    endif
-    normal f|
-    let end = col('.')-2
-    let attr = getline('.')[start:end]
-    let attr = sqhell#TrimString(attr)
-    call setpos('.', savecurpos)
-    return attr
-endfunction
-
-function! sqhell#GetTableHeader()
-    call cursor(1, 1)
-    let line = getline('.')
-    if(line[0] != '|')
-        call cursor(2, 1)
-    endif
-    let line = getline('.')
-    let line = split(line, '|')
-    let line = map(line, "sqhell#TrimString(v:val)")
-    let line = join(line, ",")
-    return line
+    execute 'let ret = ' . g:sqh_provider . '#GetColumnName()'
+    return ret
 endfunction
 
 function! sqhell#GetColumnValue()
-    let savecurpos = getcurpos()
-    let start = col('.')
-    if(getline('.')[start-1] != '|')
-        normal F|
-        let start = col('.')
-    endif
-    normal f|
-    let end = col('.')-2
-    let val = getline('.')[start:end]
-    let val = sqhell#TrimString(val)
-    call setpos('.', savecurpos)
-    return val
+    execute 'let ret = ' . g:sqh_provider . '#GetColumnValue()'
+    return ret
+endfunction
+
+function! sqhell#CreateCSVFromRow(row)
+    execute 'let ret = ' . g:sqh_provider . '#CreateCSVFromRow(a:row)'
+    return ret
+endfunction
+
+function! sqhell#GetTableHeader()
+    execute 'let ret = ' . g:sqh_provider . '#GetTableHeader()'
+    return ret
 endfunction
 
 function! sqhell#GetTableName()
@@ -134,14 +106,6 @@ function! sqhell#GetTableName()
     let db = sqhell#TrimString(tmp_db)
     execute savewin . "wincmd w"
     return [table, db]
-endfunction
-
-function! sqhell#CreateCSVFromRow(row)
-    let csv = split(a:row, "|")
-    let csv = map(csv, "sqhell#TrimString(v:val)")
-    let csv = map(csv, '"\"" . v:val . "\""')
-    let csv = join(csv, ",")
-    return csv
 endfunction
 
 function! sqhell#TrimString(str)

--- a/autoload/sqhell.vim
+++ b/autoload/sqhell.vim
@@ -18,7 +18,7 @@ endfunction
 
 "Inserts SQL results into a new temporary buffer"
 function! sqhell#ExecuteCommand(command)
-    execute "call sqhell#InsertResultsToNewBuffer('SQHResult', " . g:sqh_provider . "#GetResultsFromQuery(a:command))"
+    execute "call sqhell#InsertResultsToNewBuffer('SQHResult', " . g:sqh_provider . "#GetResultsFromQuery(a:command), 1)"
 endfunction
 
 function! sqhell#Execute(command, bang) range
@@ -48,10 +48,12 @@ function! sqhell#ExecuteFile(...)
     call sqhell#ExecuteCommand(file_content)
 endfunction
 
-function! sqhell#InsertResultsToNewBuffer(local_filetype, query_results)
+function! sqhell#InsertResultsToNewBuffer(local_filetype, query_results, format)
     new | put =a:query_results
 
-    execute "call " . g:sqh_provider . "#PostBufferFormat()"
+    if(a:format)
+        execute "call " . g:sqh_provider . "#PostBufferFormat()"
+    endif
 
     "This prevents newline characters from literally rendering out
     "Keeping this as a comment just incase anyone decides to get

--- a/autoload/sqhell.vim
+++ b/autoload/sqhell.vim
@@ -93,9 +93,22 @@ function! sqhell#GetColumnName()
     normal f|
     let end = col('.')-2
     let attr = getline('.')[start:end]
-    let attr = substitute(attr, '^\s*\(.\{-}\)\s*$', '\1', '')
+    let attr = sqhell#TrimString(attr)
     call setpos('.', savecurpos)
     return attr
+endfunction
+
+function! sqhell#GetTableHeader()
+    call cursor(1, 1)
+    let line = getline('.')
+    if(line[0] != '|')
+        call cursor(2, 1)
+    endif
+    let line = getline('.')
+    let line = split(line, '|')
+    let line = map(line, "sqhell#TrimString(v:val)")
+    let line = join(line, ",")
+    return line
 endfunction
 
 function! sqhell#GetColumnValue()
@@ -108,7 +121,7 @@ function! sqhell#GetColumnValue()
     normal f|
     let end = col('.')-2
     let val = getline('.')[start:end]
-    let val = substitute(val, '^\s*\(.\{-}\)\s*$', '\1', '')
+    let val = sqhell#TrimString(val)
     call setpos('.', savecurpos)
     return val
 endfunction
@@ -118,7 +131,19 @@ function! sqhell#GetTableName()
     wincmd p
     let table = expand('<cword>')
     let tmp_db = mysql#GetDatabaseName()
-    let db = substitute(tmp_db, '^\s*\(.\{-}\)\s*$', '\1', '')
+    let db = sqhell#TrimString(tmp_db)
     execute savewin . "wincmd w"
     return [table, db]
+endfunction
+
+function! sqhell#CreateCSVFromRow(row)
+    let csv = split(a:row, "|")
+    let csv = map(csv, "sqhell#TrimString(v:val)")
+    let csv = map(csv, '"\"" . v:val . "\""')
+    let csv = join(csv, ",")
+    return csv
+endfunction
+
+function! sqhell#TrimString(str)
+    return substitute(a:str, '^\s*\(.\{-}\)\s*$', '\1', '')
 endfunction

--- a/autoload/sqhell.vim
+++ b/autoload/sqhell.vim
@@ -19,6 +19,7 @@ endfunction
 "Inserts SQL results into a new temporary buffer"
 function! sqhell#ExecuteCommand(command)
     execute "call sqhell#InsertResultsToNewBuffer('SQHResult', " . g:sqh_provider . "#GetResultsFromQuery(a:command), 1)"
+    let b:last_query = a:command
 endfunction
 
 function! sqhell#Execute(command, bang) range

--- a/doc/sqhell.txt
+++ b/doc/sqhell.txt
@@ -176,9 +176,6 @@ SQHResult                                                      *sqhell-sqhresult
 
         Note this reloads the current SQHResult buffer
 
-
-SQHResult                                                         *sqh-sqhresult*
-
     `s` - Sort results by the column the cursor is on
 
         Equivalent to `:SQHSortResults -f`
@@ -186,6 +183,14 @@ SQHResult                                                         *sqh-sqhresult
     `S` - Sort results by the column the cursor is on (in reverse)
 
         Equivalent to `:SQHSortResults -fr`
+
+    `e` - Edit current table row. Closes current buffer (SQHResult)
+          and opens new SQHInsert buffer in current window.
+
+
+SQHInsert                                                      *sqhell-sqhinsert*
+
+    `ZZ` - Close and save row to database.
 
 
 vim:tw=78:ts=8:ft=help:norl:

--- a/ftplugin/SQHInsert.vim
+++ b/ftplugin/SQHInsert.vim
@@ -1,0 +1,1 @@
+nnoremap <buffer> ZZ :call mysql#AddRow()<cr>

--- a/ftplugin/SQHResult.vim
+++ b/ftplugin/SQHResult.vim
@@ -1,4 +1,5 @@
 " nnoremap <buffer> dd :echo 'Deletions would happen here'
-noremap <buffer> dd :call mysql#DeleteRow()<cr>
+nnoremap <buffer> dd :call mysql#DeleteRow()<cr>
 nnoremap <buffer> <silent> s :SQHSortResults -f<CR>
 nnoremap <buffer> <silent> S :SQHSortResults -fr<CR>
+nnoremap <buffer> <silent> e :call mysql#EditRow()<cr>


### PR DESCRIPTION
In this PR:
- added functionality for editing rows
- refactored trim string (previously used as substitute(...) now as a function)
- new file type: SQHInsert (buffer for inserting and editing rows)

Functionality:
- SQHResult keybinding 'e': edit current row, calls **mysql#EditRow()**
- SQHInsert keybinding 'ZZ': closes and saves the data in the buffer to the database, calls **mysql#AddRow()**
- function **sqhell#TrimString(str)**: removes trailing whitespace from string str
- function **sqhell#GetTableHeader()**: returns the table header as csv (values are not in quotes for practicality)
- function **sqhell#CreateCSVFromRow(row)**: returns the current row as csv
- function **mysql#EditRow()**: uses **mysql#CreateCSVFromRow**, **mysql#GetTableHeader**, and **mysql#GetTableName** to get necessary data; closes current buffer; puts the row data into a new buffer
- function **mysql#AddRow()**: uses **mysql#CreateUpdateFromCSV** to create query for updating the database, executes the query, and resets the SQHResult buffer (has an _if_ branch reserved for inserting new rows)
- function **mysql#CreateUpdateFromCSV()**: uses the current (SQHInsert) buffer to create a mysql update statement (gets table and database name by _t:tabInfo_ variable - tab scoped variable)