### PR TITLE
Set nostartofline in SQHResult buffers

### DIFF
--- a/ftplugin/SQHResult.vim
+++ b/ftplugin/SQHResult.vim
@@ -1,3 +1,5 @@
+setl nostartofline
+
 nnoremap <buffer> dd :call mysql#DeleteRow()<cr>
 nnoremap <buffer> <silent> s :SQHSortResults -f<CR>
 nnoremap <buffer> <silent> S :SQHSortResults -fr<CR>


### PR DESCRIPTION
Set nostartofline in SQHResult buffers, so that when scrolling (i.e. with ctrl-u or ctrl-d), the cursor stays in the same column rather than going to the beginning of the line. This is very annoying when trying to scroll through long tables that are wider than the viewing window.