### PR TITLE
Feature/insert row key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,21 +6,12 @@ os:
 
 before_script: |
   git clone https://github.com/junegunn/vader.vim.git
-  git clone https://github.com/joereynolds/SQHell.vim
-
-  git clone https://github.com/vim/vim
-  cd vim
-  ./configure --with-features=huge
-  make
-  sudo make install
-  cd -
-
 
 script: |
   vim -Nu <(cat << VIMRC
   filetype off
   set rtp+=vader.vim
-  set rtp+=SQHell.vim
+  set rtp+=./
   set rtp+=.
   set rtp+=after
   filetype plugin indent on

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,14 @@ os:
 before_script: |
   git clone https://github.com/junegunn/vader.vim.git
 
+  git clone https://github.com/vim/vim
+  cd vim
+  ./configure --with-features=huge
+  make
+  sudo make install
+  cd -
+
+
 script: |
   vim -Nu <(cat << VIMRC
   filetype off

--- a/README.md
+++ b/README.md
@@ -101,7 +101,9 @@ Inside an SQHResult you can press the following
 
 `dd` to delete the row WHERE the column is the value under the cursor (don't worry... there's a prompt).
 
-`e` to edit the current row. This will open an SQHInsert buffer
+`e` to edit the current row. This will open an SQHInsert buffer.
+
+`i` to insert a new row. This will open an SQHInsert buffer.
 
 
 ### SQHInsert

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -112,9 +112,9 @@ function! mysql#PostBufferFormat()
         return
     endif
     if(&ft == 'SQHInsert')
-        :silent! 1;/,/-1d
+        :silent! keepjumps 1;/,/-1d
     else
-        :silent! 1;/+---/-1d
+        :silent! keepjumps 1;/+---/-1d
     endif
     :nohl
 endfunction
@@ -189,7 +189,7 @@ endfunction
 function! mysql#CreateInsertFromCSV()
     let cols = split(getline(1), ',')
     let vals = split(getline(2), '"')
-    let vals = filter(vals, 'v:val != ","')
+    let vals = filter(vals, 'v:val !~ "^,"')
     let vals = map(vals, '"\"" . v:val . "\""')
 
     if len(cols) != len(vals)
@@ -223,10 +223,10 @@ function! mysql#CreateUpdateFromCSV()
     let cols = split(getline(1), ',')
     let vals = getline(2)
     let vals = split(vals, '"')
-    let vals = filter(vals, 'v:val != ","')
+    let vals = filter(vals, 'v:val !~ "^,"')
     let vals = map(vals, '"\"" . v:val . "\""')
     let b:prev = split(b:prev, '"')
-    let b:prev = filter(b:prev, 'v:val != ","')
+    let b:prev = filter(b:prev, 'v:val !~ "^,"')
     let b:prev = map(b:prev, '"\"" . v:val . "\""')
 
     if len(cols) != len(vals)

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -112,9 +112,9 @@ function! mysql#PostBufferFormat()
         return
     endif
     if(&ft == 'SQHInsert')
-        :1;/,/-1d
+        :silent! 1;/,/-1d
     else
-        :1;/+---/-1d
+        :silent! 1;/+---/-1d
     endif
     :nohl
 endfunction

--- a/autoload/sqhell.vim
+++ b/autoload/sqhell.vim
@@ -18,7 +18,7 @@ endfunction
 
 "Inserts SQL results into a new temporary buffer"
 function! sqhell#ExecuteCommand(command)
-    execute "call sqhell#InsertResultsToNewBuffer('SQHResult', " . g:sqh_provider . "#GetResultsFromQuery(a:command), 1)"
+    execute "call sqhell#InsertResultsToNewBuffer('SQHResult', " . g:sqh_provider . "#GetResultsFromQuery(a:command))"
     let b:last_query = a:command
 endfunction
 
@@ -47,12 +47,8 @@ function! sqhell#ExecuteFile(...)
     call sqhell#ExecuteCommand(l:file_content)
 endfunction
 
-function! sqhell#InsertResultsToNewBuffer(local_filetype, query_results, format)
+function! sqhell#InsertResultsToNewBuffer(local_filetype, query_results)
     enew! | put =a:query_results
-
-    if (a:format)
-        execute "call " . g:sqh_provider . "#PostBufferFormat()"
-    endif
 
     "This prevents newline characters from literally rendering out
     "Keeping this as a comment just incase anyone decides to get
@@ -64,6 +60,8 @@ function! sqhell#InsertResultsToNewBuffer(local_filetype, query_results, format)
     setlocal noswapfile
     setlocal nowrap
     execute 'setlocal filetype=' . a:local_filetype
+
+    execute "call " . g:sqh_provider . "#PostBufferFormat()"
 endfunction
 
 "Proxies to the provider of choice
@@ -97,6 +95,14 @@ endfunction
 function! sqhell#GetTableHeader()
     execute 'let ret = ' . g:sqh_provider . '#GetTableHeader()'
     return ret
+endfunction
+
+function! sqhell#EditRow()
+    execute 'call ' .g:sqh_provider . '#EditRow()'
+endfunction
+
+function! sqhell#InsertRow()
+    execute 'call ' . g:sqh_provider . '#InsertRow()'
 endfunction
 
 function! sqhell#GetTableName()

--- a/doc/sqhell.txt
+++ b/doc/sqhell.txt
@@ -177,7 +177,10 @@ SQHResult                                                      *sqhell-sqhresult
         Equivalent to `:SQHSortResults -fr`
 
     `e` - Edit current table row. Closes current buffer (SQHResult)
-          and opens new SQHInsert buffer in current window.
+          and opens a new SQHInsert buffer in current window.
+
+    `i` - Insert a new row into the table. Closes current buffer
+          and opens a new SQHInsert buffer in current window.
 
 
 SQHInsert                                                      *sqhell-sqhinsert*

--- a/ftplugin/SQHResult.vim
+++ b/ftplugin/SQHResult.vim
@@ -3,4 +3,5 @@ setl nostartofline
 nnoremap <buffer> dd :call mysql#DeleteRow()<cr>
 nnoremap <buffer> <silent> s :SQHSortResults -f<CR>
 nnoremap <buffer> <silent> S :SQHSortResults -fr<CR>
-nnoremap <buffer> <silent> e :call mysql#EditRow()<cr>
+nnoremap <buffer> <silent> e :call sqhell#EditRow()<cr>
+nnoremap <buffer> <silent> i :call sqhell#InsertRow()<cr>

--- a/test/sqhell.vader
+++ b/test/sqhell.vader
@@ -128,7 +128,7 @@ Execute (to see if the generated query is correct):
   AssertEqual expected, actual
 
 Given SQHInsert (A buffer from which to generate the UPDATE statement):
-  id,someColumn1,someColulmn2
+  id,someColumn1,someColumn2
   "2","someValue1","someValue2"
 
 Execute (to see if the generated query is correct):

--- a/test/sqhell.vader
+++ b/test/sqhell.vader
@@ -134,4 +134,6 @@ Given SQHInsert (A buffer from which to generate the UPDATE statement):
 Execute (to see if the generated query is correct):
   let t:tabInfo = 'test.test'
   let b:prev = '"1","prevValue1","prevValue2"'
-  let expected = 'UPDATE ' . t:tabInfo . ' SET id="2", someColumn1="someValue1", someColumn2="someValue2" WHERE id="1" AND someColumn1="prevValue1" AND comeColumn2="prevValue2"'
+  let expected = 'UPDATE ' . t:tabInfo . ' SET id="2", someColumn1="someValue1", someColumn2="someValue2" WHERE id="1" AND someColumn1="prevValue1" AND someColumn2="prevValue2"'
+  let actual = mysql#CreateUpdateFromCSV()
+  AssertEqual expected, actual

--- a/test/sqhell.vader
+++ b/test/sqhell.vader
@@ -8,11 +8,11 @@ Execute (to see if all commands are available):
   AssertEqual exists(':SQHDropTableFromDatabase'), 2
 
 Execute (to see whether we set the correct filetype on a buffer):
-  call sqhell#InsertResultsToNewBuffer('testType', '', 1)
+  call sqhell#InsertResultsToNewBuffer('testType', '')
   AssertEqual 'testType', &filetype
 
 Execute (to see whether we set the correct buffer local settings):
-  call sqhell#InsertResultsToNewBuffer('testType', '', 1)
+  call sqhell#InsertResultsToNewBuffer('testType', '')
   AssertEqual 'hide', &bufhidden
   AssertEqual 'nofile', &buftype
 
@@ -116,3 +116,22 @@ Expect SQHResult (the buffer to be in Reverse order by primary key):
   |  2 | Supporting      | Tivoli, Buckley, UK                 | 2017-10-20 | The Sex Pistols Experience | http://www.sexpistolsexperience.co.uk/     |
   |  1 | Supporting      | Mcleans Pub, Deeside, UK            | 2017-09-09 | Vice Squad                 | http://vicesquad.co.uk/punkrock/           |
   +----+-----------------+-------------------------------------+------------+----------------------------+--------------------------------------------+
+
+Given SQHInsert (A buffer from which to generate the INSERT statement):
+  id,someColumn1,someColumn2
+  "1","someValue1","someValue2"
+
+Execute (to see if the generated query is correct):
+  let t:tabInfo = 'test.test'
+  let expected = 'INSERT INTO ' . t:tabInfo . ' (id, someColumn1, someColumn2) VALUES("1", "someValue1", "someValue2")'
+  let actual = mysql#CreateInsertFromCSV()
+  AssertEqual expected, actual
+
+Given SQHInsert (A buffer from which to generate the UPDATE statement):
+  id,someColumn1,someColulmn2
+  "2","someValue1","someValue2"
+
+Execute (to see if the generated query is correct):
+  let t:tabInfo = 'test.test'
+  let b:prev = '"1","prevValue1","prevValue2"'
+  let expected = 'UPDATE ' . t:tabInfo . ' SET id="2", someColumn1="someValue1", someColumn2="someValue2" WHERE id="1" AND someColumn1="prevValue1" AND comeColumn2="prevValue2"'


### PR DESCRIPTION
Description (what is it you've done, has anything changed?)

- updated **mysql#PostBufferFormat** so it automatically deletes all lines before the expected output (everything before a line containing `+-----` for all SQH filetypes except SQHInsert, or everything before a line containing `,` for SQHInsert filetype) -- this could probably use some more tweeking
- added function **mysql#GetTableInfoFromQuery(query)**: returns list [database, table] names (used in **mysql#EditRow** and **mysql#InsertRow**
- added function **mysql#CreateInsertFromCSV()**: creates an INSERT sql statement from the csv in the current buffer
- added function **mysql#InsertRow()**: opens a SQHInsert buffer with the headings in csv format
- added key mapping for calling provider non-specific **xxxx#InsertRow** function
- added simple vader tests for **mysql#CreateInsertFromCSV** and **mysql#CreateUpdateFromCSV**

Checklist

- [x] I have written my code in a way that it can be easily tested
- [x] I have written tests for my code
- [x] I have documented new features in `doc/sqhell.txt`
- [x] I have added information to the README (where relevant)
- [x] I have ran the automated tests and performed manual tests.
