### PR TITLE
[WIP] Add create new database functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ Inside an SQHDatabase you can press the following
 
 `e` - To see all the tables in that database. This will open an SQHTable buffer.
 
+`c` - Create a new database (will be asked for name by input).
+
 
 ### SQHTable
 

--- a/autoload/mysql.vim
+++ b/autoload/mysql.vim
@@ -34,6 +34,23 @@ function! mysql#ShowDatabases()
     call sqhell#InsertResultsToNewBuffer('SQHDatabase', mysql#GetResultsFromQuery('SHOW DATABASES'), 1)
 endfunction
 
+function! mysql#CreateDatabase(name, show)
+    if(a:name == "")
+        call inputsave()
+        let l:name = input("Enter database name: ")
+        call inputrestore()
+    else
+        let l:name = a:name
+    endif
+
+    let l:create_query = 'CREATE DATABASE ' . l:name
+    call mysql#GetResultsFromQuery(l:create_query)
+    if(a:show)
+        :bd
+        call mysql#ShowDatabases()
+    endif
+endfunction
+
 "Shows all tables for a given database
 "Can also be ran by pressing 'e' in
 "an SQHDatabase buffer

--- a/autoload/sqhell.vim
+++ b/autoload/sqhell.vim
@@ -67,6 +67,10 @@ function! sqhell#InsertResultsToNewBuffer(local_filetype, query_results, format)
 endfunction
 
 "Proxies to the provider of choice
+function! sqhell#CreateDatabase(name, show)
+    execute 'call ' . g:sqh_provider . '#CreateDatabase("' . a:name . '", ' . a:show . ')'
+endfunction
+
 function! sqhell#ShowTablesForDatabase(database)
     execute 'call ' . g:sqh_provider . '#ShowTablesForDatabase("' . a:database.'")'
 endfunction

--- a/doc/sqhell.txt
+++ b/doc/sqhell.txt
@@ -59,6 +59,13 @@ SQHShowDatabases                                          *sqhell-show-databases
 
     Shows all databases
 
+SQHCreateDatabase                                        *sqhell-create-database*
+
+    Arguments: database name
+    Example: SQHCreateDatabase Users
+
+    Creates a new database
+
 SQHShowTablesForDatabase                        *sqhell-show-tables-for-database*
 
     Arguments: table name
@@ -158,6 +165,10 @@ SQHDatabase                                                  *sqhell-sqhdatabase
         Note this opens a buffer with a filetype of SQHTable
 
     `dd` - Drop the database.
+
+        Note this reloads the current SQHDatabase buffer
+
+    `c` - Create a new database.
 
         Note this reloads the current SQHDatabase buffer
 

--- a/ftplugin/SQHDatabase.vim
+++ b/ftplugin/SQHDatabase.vim
@@ -1,3 +1,4 @@
 "Select * from the selected table
 noremap <buffer> e :call sqhell#ShowTablesForDatabase(expand('<cword>'))<cr>
 noremap <buffer> dd :call mysql#DropDatabase(expand('<cword>'), 1)<cr>
+nnoremap <buffer> c :call sqhell#CreateDatabase("", 1)<cr>

--- a/plugin/sqhell.vim
+++ b/plugin/sqhell.vim
@@ -12,6 +12,7 @@ command! -nargs=1 SQHShowTablesForDatabase execute "call " . g:sqh_provider . "#
 command! -nargs=? -complete=file SQHExecuteFile call sqhell#ExecuteFile(<q-args>)
 command! -bang -range -nargs=* SQHExecute <line1>,<line2>:call sqhell#Execute(<q-args>, <bang>0)
 command! -nargs=1 -complete=custom,sqhell#GetHosts SQHSwitchConnection call sqhell#SwitchConnection(<q-args>)
-command! -nargs=1 SQHDropDatabase execute ":call " . g:sqh_provider . "#DropDatabase(<q-args>, 0)"
-command! -nargs=+ SQHDropTableFromDatabase execute ":call " . g:sqh_provider . "#DropTableFromDatabase(<f-args>, 0)"
-command! -nargs=* SQHSortResults execute ':call ' . g:sqh_provider . '#SortResults(<f-args>)'
+command! -nargs=1 SQHDropDatabase execute ":call " . g:sqh_provider . "#DropDatabase('" . <q-args> . "', 0)"
+command! -nargs=+ SQHDropTableFromDatabase execute ":call " . g:sqh_provider . "#DropTableFromDatabase('" . <f-args>  . "', 0)"
+command! -nargs=* SQHSortResults execute ':call ' . g:sqh_provider . '#SortResults("' . <f-args> '")'
+command! -nargs=1 SQHCreateDatabase  execute ":call " . g:sqh_provider . "#CreateDatabase('" . <q-args> . "', 0)"


### PR DESCRIPTION
Description (what is it you've done, has anything changed?)

Adds the create new database functionality.
- **mysql#CreateDatabase(name, show)** function that create a new database
- **sqhell#CreateDatabase(name, show)** generic function
- key mapping for **SQHDatabase** buffer
- **SQHCreateDatabase** command

Reasons for [WIP] (work in progress):
- uses the destroy and reopen "reload functionality" and would be better to first solve #46 
- throws an error when pressing `e` in **SQHTable** buffer that is fixed in #44 

Checklist

- [ ] I have written my code in a way that it can be easily tested
- [ ] I have written tests for my code
- [x] I have documented new features in `doc/sqhell.txt`
- [x] I have added information to the README (where relevant)
- [ ] I have ran the automated tests and performed manual tests.
